### PR TITLE
Issue 12019 Fix flaky test ManagedLedgerTest.testMaximumRolloverTime

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -1755,8 +1755,8 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         ledger.addEntry("data".getBytes());
         ledger.addEntry("data".getBytes());
-
-        assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        
+        assertEquals(ledger.getLedgersInfoAsList().size(), 2);    
     }
 
     @Test
@@ -1773,11 +1773,12 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 1);
 
-        Thread.sleep(2000);
-
         ledger.addEntry("data".getBytes());
         ledger.addEntry("data".getBytes());
-        assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        });   
     }
 
     @Test


### PR DESCRIPTION
Fixes #12019


### Motivation

Fix flaky test ManagedLedgerTest.testMaximumRolloverTime

This test was failing sporadically due to using Thread.sleep(2000). However, due to using a constant time of 2000 milliseconds, it sometimes added more entry than expected.  

### Modifications

- Remove Thread.sleep(2000)
- Put the assertion into Awaitility.await()

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] no-need-doc 